### PR TITLE
Policy abstraction refactor

### DIFF
--- a/secure-by-default.json
+++ b/secure-by-default.json
@@ -1,0 +1,58 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DenyUnSecureCommunications",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:*",
+            "Resource": [
+                "${aws_s3_bucket.bucket.arn}"
+            ],
+            "Condition": {
+                "Bool": {
+                    "aws:SecureTransport": "false"
+                }
+            }
+        },
+        {
+            "Sid": "DenyIncorrectEncryptionHeader",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:PutObject",
+            "Resource": [
+                "${aws_s3_bucket.bucket.arn}/*"
+            ],
+            "Condition": {
+                "StringNotEquals": {
+                    "s3:x-amz-server-side-encryption": "aws:kms"
+                }
+            }
+        },
+        {
+            "Sid": "DenyUnEncryptedObjectUploads",
+            "Effect": "Deny",
+            "Principal": "*",
+            "Action": "s3:PutObject",
+            "Resource": [
+                "${aws_s3_bucket.bucket.arn}/*"
+            ],
+            "Condition": {
+                "Null": {
+                    "s3:x-amz-server-side-encryption": "true"
+                }
+            }
+        },
+        {
+            "Sid": "PermitOnlyRolesWithinAccount",
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "${data.aws_caller_identity.current.account_id}"
+            },
+            "Action": "*",
+            "Resource": [
+                "${aws_s3_bucket.bucket.arn}"
+            ]
+        }
+    ]
+}

--- a/secure-by-default.json
+++ b/secure-by-default.json
@@ -7,7 +7,7 @@
             "Principal": "*",
             "Action": "s3:*",
             "Resource": [
-                "${aws_s3_bucket.bucket.arn}"
+                "${aws_s3_bucket_arn}"
             ],
             "Condition": {
                 "Bool": {
@@ -21,7 +21,7 @@
             "Principal": "*",
             "Action": "s3:PutObject",
             "Resource": [
-                "${aws_s3_bucket.bucket.arn}/*"
+                "${aws_s3_bucket_arn}/*"
             ],
             "Condition": {
                 "StringNotEquals": {
@@ -35,7 +35,7 @@
             "Principal": "*",
             "Action": "s3:PutObject",
             "Resource": [
-                "${aws_s3_bucket.bucket.arn}/*"
+                "${aws_s3_bucket_arn}/*"
             ],
             "Condition": {
                 "Null": {
@@ -47,11 +47,11 @@
             "Sid": "PermitOnlyRolesWithinAccount",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "${data.aws_caller_identity.current.account_id}"
+                "AWS": "${current_account_id}"
             },
             "Action": "*",
             "Resource": [
-                "${aws_s3_bucket.bucket.arn}"
+                "${aws_s3_bucket_arn}"
             ]
         }
     ]


### PR DESCRIPTION
The secure-by-default policy is no longer included in the s3.tf file. The policy has been moved to its own .json template file, and its resource and principal attributes are rendered in s3.tf.